### PR TITLE
missing <numeric> library to use inner_product()

### DIFF
--- a/src/splitvelocity/ftSvAverage.h
+++ b/src/splitvelocity/ftSvAverage.h
@@ -3,6 +3,7 @@
 
 #include "ofMain.h"
 #include "ftFbo.h"
+#include <numeric>
 
 namespace flowTools {
 	


### PR DESCRIPTION
missing <numeric> library to use inner_product() in the ftSvAverage.cpp file... not sure if it is because I am using 10.12.3 OSX and ofx 0.9.8 or if other were having issues with this as well. Hopefully this solves some issues others were running into with compiling the lib.